### PR TITLE
takePicture fail when autofocus is being accessed multiple times

### DIFF
--- a/app/src/main/java/com/todobom/opennotescanner/ImageProcessor.java
+++ b/app/src/main/java/com/todobom/opennotescanner/ImageProcessor.java
@@ -165,6 +165,7 @@ public class ImageProcessor extends Handler {
         picture.release();
 
         mMainActivity.setImageProcessorBusy(false);
+        mMainActivity.setAttemptToFocus(false);
         mMainActivity.waitSpinnerInvisible();
     }
 

--- a/app/src/main/java/com/todobom/opennotescanner/OpenNoteScannerActivity.java
+++ b/app/src/main/java/com/todobom/opennotescanner/OpenNoteScannerActivity.java
@@ -168,7 +168,12 @@ public class OpenNoteScannerActivity extends AppCompatActivity
         this.imageProcessorBusy = imageProcessorBusy;
     }
 
+    public void setAttemptToFocus(boolean attemptToFocus) {
+        this.attemptToFocus = attemptToFocus;
+    }
+
     private boolean imageProcessorBusy=true;
+    private boolean attemptToFocus = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -853,6 +858,12 @@ public class OpenNoteScannerActivity extends AppCompatActivity
             mCamera.autoFocus(new Camera.AutoFocusCallback() {
                 @Override
                 public void onAutoFocus(boolean success, Camera camera) {
+                    if (attemptToFocus) {
+                        return;
+                    } else {
+                        attemptToFocus = true;
+                    }
+
                     camera.takePicture(null,null,mThis);
                 }
             });


### PR DESCRIPTION
This error sometimes will pop up and crash the app. After digging around, I found out that certain devices autofocus multiple times during camera startup, in this case, Samsung phones.

The possible solution is to add a flag to check whether autofocus is in progress, if it is, just skip the takePicture function, otherwise, proceed.

Refer to here: http://stackoverflow.com/a/36478131