### PR TITLE
Deleting the last image from gallery didn't close the activity.

### DIFF
--- a/app/src/main/java/com/todobom/opennotescanner/FullScreenViewActivity.java
+++ b/app/src/main/java/com/todobom/opennotescanner/FullScreenViewActivity.java
@@ -188,6 +188,9 @@ public class FullScreenViewActivity extends AppCompatActivity {
         Utils.removeImageFromGallery(filePath,this);
 
         loadAdapter();
+        
+        if (0 == mAdapter.getCount())
+            finish();
         mViewPager.setCurrentItem(item);
     }
 


### PR DESCRIPTION
After deleting the last image, a empty image was displayed (white screen) instead of going back to the gallery. Pressing either **Delete** or **Tag** resulted in _IndexOutOfBoundsException_. 

Added a check which closes the activity when no more images are left.