### PR TITLE
Adapt "Share" intent from gallery to the number of selected documents

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/." />
         <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.8" />
         <option name="gradleJvm" value="1.7" />
         <option name="modules">
@@ -13,12 +13,7 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="myModules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-          </set>
-        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '23.0.3'
     defaultConfig {
         applicationId "com.todobom.opennotescanner"
         minSdkVersion 21

--- a/app/src/main/java/com/todobom/opennotescanner/GalleryGridActivity.java
+++ b/app/src/main/java/com/todobom/opennotescanner/GalleryGridActivity.java
@@ -333,18 +333,29 @@ public class GalleryGridActivity extends AppCompatActivity
     }
 
     public void shareImages() {
+        ArrayList<String> selectedFiles = myThumbAdapter.getSelectedFiles();
 
-        final Intent shareIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
-        shareIntent.setType("image/jpg");
+        if (selectedFiles.size() == 1) {
+            /* Only one scanned document selected: ACTION_SEND intent */
+            final Intent shareIntent = new Intent(Intent.ACTION_SEND);
+            shareIntent.setType("image/jpg");
 
-        ArrayList<Uri> filesUris = new ArrayList<>();
+            shareIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse("file://" + selectedFiles.get(0)));
 
-        for (String i : myThumbAdapter.getSelectedFiles() ) {
-            filesUris.add(Uri.parse("file://" + i));
+            startActivity(Intent.createChooser(shareIntent, getString(R.string.share_snackbar)));
+        } else {
+            ArrayList<Uri> filesUris = new ArrayList<>();
+            for (String i : myThumbAdapter.getSelectedFiles()) {
+                filesUris.add(Uri.parse("file://" + i));
+            }
+
+            final Intent shareIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
+            shareIntent.setType("image/jpg");
+
+            shareIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, filesUris);
+
+            startActivity(Intent.createChooser(shareIntent, getString(R.string.share_snackbar)));
         }
-        shareIntent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, filesUris);
-
-        startActivity(Intent.createChooser(shareIntent, getString(R.string.share_snackbar)));
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 10 12:31:09 BRT 2016
+#Tue Jul 11 23:40:44 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
The sharing button from the gallery view would always create an intent to share _multiple_ pictures, even when only one document is selected (issue #78).

Add a check for the number of selected documents: if there is only one, an intent to share only one picture is created. Thus, the same list of applications is displayed as in the full screen view.

This makes the behavior more consistent with the sharing button from the full screen view, and make it easier to export a scanned document from the gallery to other applications, e.g. PDF Creator.