### PR TITLE
Fixes #120: Sharing does not work. Fix :  using FileProvider to avoid…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,8 +60,8 @@
             android:label="@string/settings"
             android:theme="@style/AppTheme" />
         <provider
-            android:name=".GenericFileProvider"
-            android:authorities="${applicationId}.genericfileprovider"
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/app/src/main/java/com/todobom/opennotescanner/FullScreenViewActivity.java
+++ b/app/src/main/java/com/todobom/opennotescanner/FullScreenViewActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.FileProvider;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -201,9 +202,10 @@ public class FullScreenViewActivity extends AppCompatActivity {
 
         final Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("image/jpg");
-        final File photoFile = new File(mAdapter.getPath(item));
-        shareIntent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(photoFile));
-        Log.d("Fullscreen","uri "+Uri.fromFile(photoFile));
+        Uri uri = FileProvider.getUriForFile(getApplicationContext(), getPackageName()+".fileprovider", new File(mAdapter.getPath(item)));
+        shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        Log.d("Fullscreen","uri "+uri);
+
         startActivity(Intent.createChooser(shareIntent, getString(R.string.share_snackbar)));
     }
 

--- a/app/src/main/java/com/todobom/opennotescanner/GalleryGridActivity.java
+++ b/app/src/main/java/com/todobom/opennotescanner/GalleryGridActivity.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.FileProvider;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.GridLayoutManager;
@@ -340,13 +341,17 @@ public class GalleryGridActivity extends AppCompatActivity
             final Intent shareIntent = new Intent(Intent.ACTION_SEND);
             shareIntent.setType("image/jpg");
 
-            shareIntent.putExtra(Intent.EXTRA_STREAM, Uri.parse("file://" + selectedFiles.get(0)));
+            Uri uri = FileProvider.getUriForFile(getApplicationContext(), getPackageName()+".fileprovider", new File(selectedFiles.get(0)));
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+            Log.d("GalleryGridActivity","uri "+uri);
 
             startActivity(Intent.createChooser(shareIntent, getString(R.string.share_snackbar)));
         } else {
             ArrayList<Uri> filesUris = new ArrayList<>();
             for (String i : myThumbAdapter.getSelectedFiles()) {
-                filesUris.add(Uri.parse("file://" + i));
+                Uri uri = FileProvider.getUriForFile(getApplicationContext(), getPackageName()+".fileprovider", new File(i));
+                filesUris.add(uri);
+                Log.d("GalleryGridActivity","uri "+uri);
             }
 
             final Intent shareIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);

--- a/app/src/main/java/com/todobom/opennotescanner/GenericFileProvider.java
+++ b/app/src/main/java/com/todobom/opennotescanner/GenericFileProvider.java
@@ -1,5 +1,0 @@
-package com.todobom.opennotescanner;
-
-import android.support.v4.content.FileProvider;
-
-public class GenericFileProvider extends FileProvider {}

--- a/app/src/main/java/com/todobom/opennotescanner/helpers/CustomOpenCVLoader.java
+++ b/app/src/main/java/com/todobom/opennotescanner/helpers/CustomOpenCVLoader.java
@@ -117,7 +117,7 @@ public class CustomOpenCVLoader extends OpenCVLoader {
 
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                                 installIntent = new Intent(Intent.ACTION_INSTALL_PACKAGE);
-                                uri = android.support.v4.content.FileProvider.getUriForFile(ctxt,ctxt.getApplicationContext().getPackageName() + ".genericfileprovider", apkFile);
+                                uri = android.support.v4.content.FileProvider.getUriForFile(ctxt,ctxt.getApplicationContext().getPackageName() + ".fileprovider", apkFile);
                             } else {
                                 installIntent = new Intent(Intent.ACTION_VIEW);
                                 uri = Uri.fromFile(apkFile);


### PR DESCRIPTION
… FileUriExposedException when sharing files.

## Description

This commit fixes an issue where sharing would cause a crash due to a [FileUriExposedException](https://developer.android.com/reference/android/os/FileUriExposedException) being thrown when using `"file://"+filepath` to share images instead of using a `FileProvider`.

Fixes #120 

## Type of change
Just put an x in the [] which are valid.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [x] `./gradlew checkstyle`
- [x] `Tested on _emulated_ Nexus One, Android 5.1, API 21
- [x] `Tested on _emulated_ Nexus 5X, Android 8.1, API 27
- [x] `Tested on Samsung GT-I8190, Android 7.1.1, API 25

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
