### PR TITLE
update gradle wrapper from 4.6 to to 5.6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip


### PR DESCRIPTION
## Description

This fixes an error with gradle not building the project with jdk 12

I was able to verify `gradlew assembleDebug assembleRelease` works but wasn't able to test checkstyle


Fixes #(issue)

## Type of change
Just put an x in the [] which are valid.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ x ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

# Checklist:
- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
