### PR TITLE
Place hard-coded strings into strings.xml

### DIFF
--- a/app/src/main/res/layout/dialog_scan_topic.xml
+++ b/app/src/main/res/layout/dialog_scan_topic.xml
@@ -10,7 +10,7 @@
         android:id="@+id/editTextScanTopic"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="please provide a scan topic"
+        android:hint="@string/scan_topic_placeholder"
         android:inputType="text"
         android:padding="15dp"/>
 

--- a/app/src/main/res/layout/tageditor_view.xml
+++ b/app/src/main/res/layout/tageditor_view.xml
@@ -12,7 +12,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceLarge"
-            android:text="Standard Tags:"
+            android:text="@string/standard_tags"
             android:id="@+id/textView"
             android:layout_gravity="left|top" />
 
@@ -86,7 +86,7 @@
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Done"
+            android:text="@string/done"
             android:id="@+id/tag_done"
             android:layout_alignEnd="@+id/linearLayout"
             android:layout_alignLeft="@+id/linearLayout"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -81,4 +81,7 @@
     <string name="close">Fermer</string>
     <string name="donation_pending">Don précédent en attente</string>
     <string name="custom_scan_topic_summary">Activer la personnalisation du sujet pour le nom du fichier de la numérisation</string>
+    <string name="standard_tags">Étiquettes</string>
+    <string name="done">Terminé</string>
+    <string name="scan_topic_placeholder">Fournir un sujet</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,4 +80,7 @@
     <string name="close">Close</string>
     <string name="donation_pending">Previous donation pending</string>
     <string name="custom_scan_topic_summary">Enable setting a custom topic to scan file name</string>
+    <string name="standard_tags">Standard tags</string>
+    <string name="done">Done</string>
+    <string name="scan_topic_placeholder">Please provide a topic</string>
 </resources>


### PR DESCRIPTION
## Description
Putting 3 hard-coded English strings into the `strings.xml`

Relevant to issue #35 .

## Type of change
Just put an x in the [] which are valid.
- [x] Translation Contribution (non-breaking change which only adds or updates the translation to a language)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- [ ] `./gradlew assembleDebug assembleRelease`
- [ ] `./gradlew checkstyle`

I ran it on my phone
![Screenshot_20201011-134950](https://user-images.githubusercontent.com/11246258/95686222-88b82180-0bca-11eb-8c2e-d046cff7eb50.png)
![Screenshot_20201011-135030](https://user-images.githubusercontent.com/11246258/95686223-8950b800-0bca-11eb-8c2b-285b0211daa3.png)



I always get this error despite installing different versions of Java on my Linux Mint 20 machine.
```
java.lang.module.FindException: Module java.se.ee not found
```

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

# License:
- [X] I hereby declare that all my contributions to this project is licensed using the [GPL Version 3 License](https://github.com/ctodobom/OpenNoteScanner/blob/master/GPLv3.TXT) unless specified directly on source files
