### PR TITLE
Fix GPL version typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ License
 
 Copyright 2016 - Claudemir Todo Bom
 
-Software licensed under the GPL version 2 available in GPLv3.TXT and
+Software licensed under the GPL version 3 available in GPLv3.TXT and
 online on http://www.gnu.org/licenses/gpl.txt.
 
 Use parts from other developers, sometimes with small changes,


### PR DESCRIPTION
## Description

Fix GPL version typo in README.md

## Type of change
Fix GPL version typo in README.md

# How Has This Been Tested?
not needed

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

# License:
- [X] I hereby declare that all my contributions to this project is licensed using the [GPL Version 3 License](https://github.com/ctodobom/OpenNoteScanner/blob/master/GPLv3.TXT) unless specified directly on source files
